### PR TITLE
lua/aw_watcher/init.lua: send heartbeat on BufLeave

### DIFF
--- a/lua/aw_watcher/init.lua
+++ b/lua/aw_watcher/init.lua
@@ -35,7 +35,7 @@ local function create_autocommands()
 
     local function make_heartbeat_cmd()
         vim.api.nvim_create_autocmd(
-            { "CursorMoved", "BufEnter", "CursorMovedI", "CmdlineEnter", "CmdlineChanged" },
+            { "CursorMoved", "BufLeave", "BufEnter", "CursorMovedI", "CmdlineEnter", "CmdlineChanged" },
             { group = augroup, callback = heartbeat }
         )
     end


### PR DESCRIPTION
When switching buffers, watcher should sent 2 events to aw server, one for leaving buffer and the other for entering. Right now event is only sent on buffer entry which results in data loss. Consider the case:

1. modify file A (event is sent for file A)
2. ponder for a minute without typing anything
3. switch buffer to B (only event for file B is sent now)

Now the whole minute of working on A is gone.

By sending event for A then B, this will make sure that this one minute is recorded and not lost.