### PR TITLE
Remove trailing newline characters from git branch

### DIFF
--- a/lua/aw_watcher/utils.lua
+++ b/lua/aw_watcher/utils.lua
@@ -19,7 +19,7 @@ local function set_project_name()
 end
 
 local function set_branch_name()
-    local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD")
+    local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD"):gsub("\n", "")
     vim.b.branch_name = branch == "" and "unknown" or branch
     return vim.b.branch_name
 end

--- a/lua/aw_watcher/utils.lua
+++ b/lua/aw_watcher/utils.lua
@@ -19,7 +19,7 @@ local function set_project_name()
 end
 
 local function set_branch_name()
-    local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD"):gsub("\n", "")
+    local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD 2>/dev/null"):gsub("\n", "")
     vim.b.branch_name = branch == "" and "unknown" or branch
     return vim.b.branch_name
 end


### PR DESCRIPTION
On MacOS, the parsing of the git branch results in an added newline character:
```
 - 2025-07-25 12:50:36 (0:00:02) {'branch': 'main\n', 'file': 'README.md', 'language': 'markdown', 'project': 'nvim'}
```

This PR removes these characters, if they are present. I don't know if this is a MacOS specific bug, or even only local to my machine, but i think it wouldn't hurt to add this check to all systems. What dou you think?

EDIT:
Also, if I'm not in a git repository, the git error gets written in the branch field:
```
- 2025-07-25 13:12:40 (0:00:12) {'branch': 'fatal: not a git repository (or any of the parent directories): .git', 'file': 'test.sh', 'language': 'sh', 'project': 'test'}
 ```
 I added a commit to supress stderr.
 
Thanks for the plugin!