### PR TITLE
fix: correct curl invocation to use -X POST instead of positional POST

### DIFF
--- a/lua/aw_watcher/aw_client.lua
+++ b/lua/aw_watcher/aw_client.lua
@@ -43,7 +43,7 @@ function Client.__post(self, url, data)
 
     local body = vim.fn.json_encode(data)
 
-    local args = { "POST", url, "-H", "Content-Type: application/json", "--data-raw", body }
+    local args = { "-X", "POST", url, "-H", "Content-Type: application/json", "--data-raw", body }
 
     local handle
     ---@diagnostic disable-next-line: missing-fields


### PR DESCRIPTION
```
curl treats { "POST", url, ... } as two positional URL arguments, making a GET request to http://POST before the real request. This causes an ~8 second stall on every heartbeat interval. Use -X POST to pass the HTTP method correctly.

Authored By: opencode (anthropic/claude-sonnet-4-6)
Reviewed By: Craig Barber (craigb@mojotech.com)
```

Fixes: https://github.com/lowitea/aw-watcher.nvim/issues/6

In-place config fix:
```
{
  "lowitea/aw-watcher.nvim",
  opts = {
    aw_server = {
      host = "127.0.0.1",
      port = 5600,
    },
  },
  config = function(_, opts)
    local aw = require("aw_watcher")
    aw.setup(opts)
    local client = aw.__private.aw
    client.__post = function(self, url, data)
      local body = vim.fn.json_encode(data)
      local args = { "-X", "POST", url, "-H", "Content-Type: application/json", "--data-raw", body }
      local handle
      handle = vim.loop.spawn("curl", { args = args, verbatim = false }, function(code)
        self.connected = code == 0
        if handle and not handle:is_closing() then handle:close() end
      end)
    end
  end,
}
```