### PR TITLE
Fix timing issue with heartbeat and improve connection error logic

### DIFF
--- a/lua/aw_watcher/aw_client.lua
+++ b/lua/aw_watcher/aw_client.lua
@@ -43,7 +43,7 @@ function Client.__post(self, url, data)
 
     local body = vim.fn.json_encode(data)
 
-    local args = { "POST", url, "-H", "Content-Type: application/json", "--data-raw", body }
+    local args = { "-s", "-f", "-X", "POST", url, "-H", "Content-Type: application/json", "--data-raw", body }
 
     local handle
     ---@diagnostic disable-next-line: missing-fields
@@ -74,7 +74,7 @@ function Client.heartbeat(self)
     local now = vim.uv.now()
 
     if not self.connected then
-        if self.last_error_notify and (now - self.last_error_notify > ERR_NOTIFY_INTERVAL_MS) then
+        if not self.last_error_notify or (now - self.last_error_notify > ERR_NOTIFY_INTERVAL_MS) then
             utils.notify("Not connected. Use :AWStart to try again.", vim.log.levels.WARN)
             self.last_error_notify = now
         end

--- a/lua/aw_watcher/aw_client.lua
+++ b/lua/aw_watcher/aw_client.lua
@@ -1,7 +1,7 @@
 local utils = require("aw_watcher.utils")
 
-local ERR_NOTIFY_INTERVAL = 60 -- seconds
-local HEARTBEAT_MIN_INTERVAL = 8 -- seconds
+local ERR_NOTIFY_INTERVAL_MS = 60 * 1000 -- milliseconds
+local HEARTBEAT_MIN_INTERVAL_MS = 8 * 1000 -- milliseconds
 
 ---@class Client
 local Client = {}
@@ -74,14 +74,14 @@ function Client.heartbeat(self)
     local now = vim.uv.now()
 
     if not self.connected then
-        if self.last_error_notify and (now - self.last_error_notify > ERR_NOTIFY_INTERVAL) then
+        if self.last_error_notify and (now - self.last_error_notify > ERR_NOTIFY_INTERVAL_MS) then
             utils.notify("Not connected. Use :AWStart to try again.", vim.log.levels.WARN)
             self.last_error_notify = now
         end
         return
     end
 
-    if now - self.last_heartbeat < HEARTBEAT_MIN_INTERVAL then
+    if now - self.last_heartbeat < HEARTBEAT_MIN_INTERVAL_MS then
         return
     end
 


### PR DESCRIPTION
- The variables ERR_NOTIFY_INTERVAL and HEARTBEAT_MIN_INTERVAL used seconds values, but they are being compared with values returned from vim.uv.now() which returns milliseconds
- Renamed the variables to clarify the time unit and multiplied the values by 1000 to give milliseconds durations
- Fixes #10
- Fixes #12 